### PR TITLE
Move RcSeparator into the Rancher Components library

### DIFF
--- a/.eslintrc.default.js
+++ b/.eslintrc.default.js
@@ -197,7 +197,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/RcDropdownSeparator.vue', '**/RcSeparator.vue'],
+      files: ['**/RcSeparator.vue'],
       rules: { 'local-rules/no-hr-element': 'off' }
     },
     {

--- a/eslint-plugin-local-rules/no-hr-element.js
+++ b/eslint-plugin-local-rules/no-hr-element.js
@@ -13,7 +13,7 @@ module.exports = {
           context.report({
             node,
             loc:     node.loc,
-            message: 'Use <RcSeparator> instead of <hr>. For menu/listbox separators use <RcDropdownSeparator>.'
+            message: 'Use <RcSeparator> (import { RcSeparator } from \'@components/RcSeparator\') instead of <hr>. For menu/listbox separators use <RcDropdownSeparator>.'
           });
         }
       }

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -19,7 +19,7 @@ import FileSelector from '@shell/components/form/FileSelector.vue';
 import { MANAGED_TEMPLATE_PREFIX, parseTags } from '../util/aws';
 import * as AWS from '@shell/types/aws-sdk';
 import { DEFAULT_NODE_GROUP_CONFIG } from './CruEKS.vue';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 // map between fields in rancher eksConfig and amazon launch templates
 const launchTemplateFieldMapping: {[key: string]: string} = {

--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -14,7 +14,7 @@ import KeyValue from '@shell/components/form/KeyValue.vue';
 import AuthScopes from './AuthScopes.vue';
 import { GKEImageTypes } from '@shell/components/google/util/gcp';
 import type { GKEMachineTypeOption } from '@shell/components/google/types/index.d.ts';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default defineComponent({
   name: 'GKENodePool',

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -28,7 +28,7 @@ import {
 } from '@shell/utils/uiplugins';
 import { isRancherPrime, getVersionData } from '@shell/config/version';
 import { RcButton } from '@components/RcButton';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const HARVESTER_REPO = isRancherPrime() ? HARVESTER_RANCHER_REPO : HARVESTER_COMMUNITY_REPO;
 

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -39,7 +39,7 @@ import { isValidMac } from '@shell/utils/validators/cidr';
 import { HCI as HCI_ANNOTATIONS, STORAGE } from '@shell/config/labels-annotations';
 import { isEqual } from 'lodash';
 import { FilterArgs, PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const STORAGE_NETWORK = 'storage-network.settings.harvesterhci.io';
 const HARVESTER_CPU_MODEL = 'harvester-system/node-cpu-model-configuration';

--- a/pkg/rancher-components/src/components/Card/Card.vue
+++ b/pkg/rancher-components/src/components/Card/Card.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import RcSeparator from '@shell/components/RcSeparator.vue';
+import RcSeparator from '@components/RcSeparator/RcSeparator.vue';
 
 export default defineComponent({
 

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownSeparator.test.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownSeparator.test.ts
@@ -1,0 +1,18 @@
+import { mount } from '@vue/test-utils';
+import { RcDropdownSeparator } from '@components/RcDropdown';
+
+describe('component: RcDropdownSeparator', () => {
+  it('renders a meaningful horizontal separator for menu and listbox contexts', () => {
+    const wrapper = mount(RcDropdownSeparator);
+
+    expect(wrapper.element.tagName).toBe('HR');
+    expect(wrapper.attributes('role')).toBe('separator');
+    expect(wrapper.attributes('aria-orientation')).toBe('horizontal');
+  });
+
+  it('passes attributes through to the underlying separator', () => {
+    const wrapper = mount(RcDropdownSeparator, { attrs: { class: 'ns-divider' } });
+
+    expect(wrapper.classes()).toContain('ns-divider');
+  });
+});

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownSeparator.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownSeparator.vue
@@ -1,6 +1,7 @@
+<script setup lang="ts">
+import RcSeparator from '@components/RcSeparator/RcSeparator.vue';
+</script>
+
 <template>
-  <hr
-    role="separator"
-    aria-orientation="horizontal"
-  >
+  <RcSeparator :decorative="false" />
 </template>

--- a/pkg/rancher-components/src/components/RcSeparator/RcSeparator.test.ts
+++ b/pkg/rancher-components/src/components/RcSeparator/RcSeparator.test.ts
@@ -1,0 +1,54 @@
+import { shallowMount } from '@vue/test-utils';
+import RcSeparator from './RcSeparator.vue';
+
+describe('component: RcSeparator', () => {
+  it('renders an hr element', () => {
+    const wrapper = shallowMount(RcSeparator);
+
+    expect(wrapper.element.tagName).toBe('HR');
+  });
+
+  it('hides the separator from the accessibility tree by default', () => {
+    const wrapper = shallowMount(RcSeparator);
+
+    expect(wrapper.attributes('role')).toBe('none');
+    expect(wrapper.attributes('aria-orientation')).toBeUndefined();
+  });
+
+  it('exposes a horizontal separator role when it is not decorative', () => {
+    const wrapper = shallowMount(RcSeparator, { props: { decorative: false } });
+
+    expect(wrapper.attributes('role')).toBe('separator');
+    expect(wrapper.attributes('aria-orientation')).toBe('horizontal');
+  });
+
+  it('exposes the orientation of a vertical separator when it is not decorative', () => {
+    const wrapper = shallowMount(RcSeparator, { props: { decorative: false, orientation: 'vertical' } });
+
+    expect(wrapper.attributes('role')).toBe('separator');
+    expect(wrapper.attributes('aria-orientation')).toBe('vertical');
+  });
+
+  it('does not expose an orientation for a decorative vertical separator', () => {
+    const wrapper = shallowMount(RcSeparator, { props: { orientation: 'vertical' } });
+
+    expect(wrapper.attributes('role')).toBe('none');
+    expect(wrapper.attributes('aria-orientation')).toBeUndefined();
+  });
+
+  it.each([
+    ['horizontal' as const, false],
+    ['vertical' as const, true],
+  ])('applies the vertical class only for a vertical orientation: %s', (orientation, expected) => {
+    const wrapper = shallowMount(RcSeparator, { props: { orientation } });
+
+    expect(wrapper.classes().includes('vertical')).toBe(expected);
+  });
+
+  it('passes attributes through to the root element', () => {
+    const wrapper = shallowMount(RcSeparator, { attrs: { class: 'ns-divider', 'data-testid': 'separator' } });
+
+    expect(wrapper.classes()).toContain('ns-divider');
+    expect(wrapper.attributes('data-testid')).toBe('separator');
+  });
+});

--- a/pkg/rancher-components/src/components/RcSeparator/RcSeparator.vue
+++ b/pkg/rancher-components/src/components/RcSeparator/RcSeparator.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { RcSeparatorProps } from './types';
+
+const props = withDefaults(defineProps<RcSeparatorProps>(), {
+  decorative:  true,
+  orientation: 'horizontal',
+});
+
+/**
+ * Decorative separators are removed from the accessibility tree so that screen
+ * readers skip over them. Meaningful separators keep the `separator` role and
+ * expose their orientation.
+ */
+const role = computed(() => (props.decorative ? 'none' : 'separator'));
+
+const ariaOrientation = computed(() => (props.decorative ? undefined : props.orientation));
+</script>
+
+<template>
+  <hr
+    :role="role"
+    :aria-orientation="ariaOrientation"
+    :class="{ vertical: props.orientation === 'vertical' }"
+  >
+</template>
+
+<style lang="scss" scoped>
+hr.vertical {
+  align-self: stretch;
+  height: auto;
+  margin: 0;
+  border-top: none;
+  border-left: 1px solid var(--border);
+}
+</style>

--- a/pkg/rancher-components/src/components/RcSeparator/index.ts
+++ b/pkg/rancher-components/src/components/RcSeparator/index.ts
@@ -1,0 +1,2 @@
+export { default as RcSeparator } from './RcSeparator.vue';
+export type { RcSeparatorProps, RcSeparatorOrientation } from './types';

--- a/pkg/rancher-components/src/components/RcSeparator/types.ts
+++ b/pkg/rancher-components/src/components/RcSeparator/types.ts
@@ -1,0 +1,17 @@
+export type RcSeparatorOrientation = 'horizontal' | 'vertical';
+
+export interface RcSeparatorProps {
+  /**
+   * Purely cosmetic separator that is hidden from the accessibility tree.
+   *
+   * Set to `false` when the separator conveys meaning, for example when
+   * grouping tems within a menu or a listbox.
+   */
+  decorative?: boolean;
+
+  /**
+   * Orientation of the separator. Drives `aria-orientation` when the
+   * separator is not decorative.
+   */
+  orientation?: RcSeparatorOrientation;
+}

--- a/pkg/rancher-components/src/index.ts
+++ b/pkg/rancher-components/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from './components/RcDropdown';
 export { RcIcon } from './components/RcIcon';
 export { RcSection } from './components/RcSection';
+export { RcSeparator } from './components/RcSeparator';
 export { RcItemCard, RcItemCardAction } from './components/RcItemCard';
 export { default as RcCounterBadge } from './components/Pill/RcCounterBadge';
 export { default as RcStatusBadge } from './components/Pill/RcStatusBadge';

--- a/pkg/rancher-components/types/index.d.ts
+++ b/pkg/rancher-components/types/index.d.ts
@@ -17,6 +17,7 @@ export const RcDropdownItem: DefineComponent;
 export const RcDropdownSeparator: DefineComponent;
 export const RcDropdownTrigger: DefineComponent;
 export const RcItemCard: DefineComponent;
+export const RcSeparator: DefineComponent;
 
 type ArrayListRow = {
     value: string;

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -22,7 +22,7 @@ import {
 
 import { BEFORE_SAVE_HOOKS } from '@shell/mixins/child-hook';
 import Wizard from '@shell/components/Wizard';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export const CONTEXT_HOOK_EDIT_YAML = 'show-preview-yaml';
 

--- a/shell/components/RcSeparator.vue
+++ b/shell/components/RcSeparator.vue
@@ -1,9 +1,0 @@
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({ name: 'RcSeparator' });
-</script>
-
-<template>
-  <hr role="none">
-</template>

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -14,7 +14,7 @@ import { useLabeledFormElement, labeledFormElementProps } from '@shell/composabl
 import { useLabeledSelect } from '@shell/composables/useLabeledSelect';
 import { ref, toRef } from 'vue';
 import { useVeeValidateField } from '@shell/composables/useVeeValidateField';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   name: 'LabeledSelect',

--- a/shell/components/form/Probe.vue
+++ b/shell/components/form/Probe.vue
@@ -7,7 +7,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ShellInput from '@shell/components/form/ShellInput';
 import KeyValue from '@shell/components/form/KeyValue';
 import { computed, ref, watch } from 'vue';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const KINDS = [
   'none',

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -1,7 +1,7 @@
 <script>
 import Type from '@shell/components/nav/Type';
 import { filterLocationValidParams } from '@shell/utils/router';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   name: 'Group',

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -18,7 +18,7 @@ import Pinned from '@shell/components/nav/Pinned';
 import sideNavService from '@shell/components/nav/TopLevelMenu.helper';
 import { debounce } from 'lodash';
 import { sameContents } from '@shell/utils/array';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -19,7 +19,7 @@ import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBann
 import formRulesGenerator from '@shell/utils/validators/formRules/index';
 import { useFormValidation } from '@shell/composables/useFormValidation';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const TENANT_ID_TOKEN = '__[[TENANT_ID]]__';
 

--- a/shell/edit/auth/github.vue
+++ b/shell/edit/auth/github.vue
@@ -19,7 +19,7 @@ import FileSelector from '@shell/components/form/FileSelector';
 import GithubSteps from '@shell/edit/auth/github-steps.vue';
 import GithubAppSteps from '@shell/edit/auth/github-app-steps.vue';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/edit/auth/googleoauth.vue
+++ b/shell/edit/auth/googleoauth.vue
@@ -12,7 +12,7 @@ import FileSelector from '@shell/components/form/FileSelector';
 import AuthBanner from '@shell/components/auth/AuthBanner';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const NAME = 'googleoauth';
 

--- a/shell/edit/auth/ldap/index.vue
+++ b/shell/edit/auth/ldap/index.vue
@@ -15,7 +15,7 @@ import AuthBanner from '@shell/components/auth/AuthBanner';
 import Password from '@shell/components/form/Password';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const AUTH_TYPE = 'ldap';
 

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -21,7 +21,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import { BASE_SCOPES } from '@shell/store/auth';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText.vue';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const PKCE_S256 = 'S256';
 

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -19,7 +19,7 @@ import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBann
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 import { RcButton } from '@components/RcButton';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 // Standard LDAP defaults
 const LDAP_DEFAULTS = {

--- a/shell/edit/fleet.cattle.io.cluster.vue
+++ b/shell/edit/fleet.cattle.io.cluster.vue
@@ -7,7 +7,7 @@ import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { _VIEW } from '@shell/config/query-params';
 import { NORMAN } from '@shell/config/types';
 import { FLEET } from '@shell/config/labels-annotations';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   name: 'CruFleetCluster',

--- a/shell/edit/monitoring.coreos.com.route.vue
+++ b/shell/edit/monitoring.coreos.com.route.vue
@@ -19,7 +19,7 @@ import { MONITORING } from '@shell/config/types';
 import { Banner } from '@components/Banner';
 import { createDefaultRouteName } from '@shell/utils/alertmanagerconfig';
 import Loading from '@shell/components/Loading';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -10,7 +10,7 @@ import { MANAGEMENT } from '@shell/config/types';
 import { STACK_PREFS } from './tabs/networking/index.vue';
 
 import { sanitizeKey, sanitizeIP, sanitizeValue } from '@shell/utils/string';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   emits: ['copied-windows'],

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
@@ -11,7 +11,7 @@ import { randomStr } from '@shell/utils/string';
 import FormValidation from '@shell/mixins/form-validation';
 import { MACHINE_POOL_VALIDATION } from '@shell/utils/validators/machine-pool';
 import { isAutoscalerFeatureFlagEnabled } from '@shell/utils/autoscaler-utils';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
 

--- a/shell/list/harvesterhci.io.management.cluster.vue
+++ b/shell/list/harvesterhci.io.management.cluster.vue
@@ -9,7 +9,7 @@ import { CAPI, HCI, MANAGEMENT } from '@shell/config/types';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import { allHash } from '@shell/utils/promise';
 import { RcButton } from '@components/RcButton';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -17,7 +17,7 @@ import { findBy } from '@shell/utils/array';
 import KeyValue from '@shell/components/form/KeyValue';
 import { RadioGroup } from '@components/Form/Radio';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export const azureEnvironments = [
   { value: 'AzurePublicCloud' },

--- a/shell/pages/account/index.vue
+++ b/shell/pages/account/index.vue
@@ -11,7 +11,7 @@ import { Banner } from '@components/Banner';
 import ResourceTable from '@shell/components/ResourceTable';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 import TabTitle from '@shell/components/TabTitle';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const API_ENDPOINT = '/v3';
 

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -21,7 +21,7 @@ import { isLocalhost, isValidUrl } from '@shell/utils/validators/setting';
 import Loading from '@shell/components/Loading';
 import { getBrandMeta } from '@shell/utils/brand';
 import { findMe } from '@shell/utils/auth';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const calcIsFirstLogin = (store) => {
   const firstLoginSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -47,7 +47,7 @@ import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthS
 import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
 import { PRIVATE_REGISTRY_CONTEXT } from '@shell/components/form/PrivateRegistry.constants';
 import { generateRandomAlphaString } from '@shell/utils/string';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const VALUES_STATE = {
   FORM: 'FORM',

--- a/shell/pages/c/_cluster/fleet/application/create.vue
+++ b/shell/pages/c/_cluster/fleet/application/create.vue
@@ -10,7 +10,7 @@ import FleetUtils from '@shell/utils/fleet';
 import Masthead from '@shell/components/ResourceDetail/Masthead';
 import suseLogo from '@shell/assets/images/content/suse.svg';
 import suseLogoDark from '@shell/assets/images/content/dark/suse.svg';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 interface Subtype {
   id: string;

--- a/shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue
+++ b/shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue
@@ -17,7 +17,7 @@ import Banner from '@components/Banner/Banner.vue';
 import Loading from '@shell/components/Loading';
 import { RcButton } from '@components/RcButton';
 import AppCoPageHeader from '@shell/components/fleet/AppCoPageHeader.vue';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const ADD_NEW_TOKEN = '__add_new__';
 

--- a/shell/pages/c/_cluster/istio/index.vue
+++ b/shell/pages/c/_cluster/istio/index.vue
@@ -4,7 +4,7 @@ import { SERVICE } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
 import kialiSvg from '~shell/assets/images/vendor/kiali.svg';
 import jaegerSvg from '~shell/assets/images/vendor/jaeger.svg';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: { Loading, RcSeparator },

--- a/shell/pages/c/_cluster/longhorn/index.vue
+++ b/shell/pages/c/_cluster/longhorn/index.vue
@@ -5,7 +5,7 @@ import IconMessage from '@shell/components/IconMessage';
 import LazyImage from '@shell/components/LazyImage';
 import longhornSvg from '~shell/assets/images/vendor/longhorn.svg';
 import Loading from '@shell/components/Loading';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/pages/c/_cluster/monitoring/index.vue
+++ b/shell/pages/c/_cluster/monitoring/index.vue
@@ -11,7 +11,7 @@ import { canViewAlertManagerLink, canViewGrafanaLink, canViewPrometheusLink } fr
 import Loading from '@shell/components/Loading';
 import grafanaSrc from '~shell/assets/images/vendor/grafana.svg';
 import prometheusSrc from '~shell/assets/images/vendor/prometheus.svg';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/pages/c/_cluster/neuvector/index.vue
+++ b/shell/pages/c/_cluster/neuvector/index.vue
@@ -5,7 +5,7 @@ import { NEU_VECTOR_NAMESPACE } from '@shell/config/product/neuvector';
 import LazyImage from '@shell/components/LazyImage';
 import Loading from '@shell/components/Loading';
 import neuvectorSvg from '~shell/assets/images/vendor/neuvector.svg';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -9,7 +9,7 @@ import GrowlManager from '@shell/components/GrowlManager';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 import PromptModal from '@shell/components/PromptModal';
 import { RcButton } from '@components/RcButton';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
 

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -17,7 +17,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
 import LocaleSelector from '@shell/components/LocaleSelector';
 import TabTitle from '@shell/components/TabTitle';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/storybook/src/stories/Components/RcSeparator.stories.ts
+++ b/storybook/src/stories/Components/RcSeparator.stories.ts
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { RcSeparator } from '@components/RcSeparator';
+import type { RcSeparatorOrientation } from '@components/RcSeparator/types';
+
+const meta: Meta<typeof RcSeparator> = {
+  component:  RcSeparator,
+  parameters: {
+    docs: {
+      description: {
+        component: `A thin wrapper around \`<hr>\` that gets its accessibility semantics from props.
+
+By default the separator is decorative: it renders \`role="none"\` so that screen readers skip over it, which is the correct treatment for separators that exist purely to break up content visually.
+
+Set \`decorative\` to \`false\` when the separator conveys meaning (e.g. groups items within a menu or a listbox). When \`decorative\` is \`false\`, RcSeparator renders \`role="separator"\` along with an \`aria-orientation\`.
+
+The component ships no visual styling for horizontal separators; consumers style them, typically with \`border-top: 1px solid var(--border)\`.`,
+      },
+    },
+  },
+  argTypes: {
+    decorative: {
+      control:     { type: 'boolean' },
+      description: 'Purely cosmetic separator that is hidden from the accessibility tree. Defaults to `true`.',
+    },
+    orientation: {
+      options:     ['horizontal', 'vertical'] as RcSeparatorOrientation[],
+      control:     { type: 'select' },
+      description: 'Orientation of the separator. Drives `aria-orientation` when the separator is not decorative.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RcSeparator>;
+
+const decorativeTemplate = `<div style="display: flex; flex-direction: column; gap: 20px; width: 300px;">
+  <p style="margin: 0;">Content above the separator</p>
+  <RcSeparator v-bind="args" style="border-top: 1px solid var(--border);" />
+  <p style="margin: 0;">Content below the separator</p>
+</div>`;
+
+export const Decorative: Story = {
+  render: (args: any) => ({
+    components: { RcSeparator },
+    setup() {
+      return { args };
+    },
+    template: decorativeTemplate,
+  }),
+  args:       { decorative: true, orientation: 'horizontal' },
+  parameters: {
+    docs: {
+      description: { story: 'The default. Renders `role="none"` so the separator is not announced by screen readers.' },
+      canvas:      { sourceState: 'shown' },
+      source:      { code: decorativeTemplate },
+    },
+  },
+};
+
+const semanticTemplate = `<ul role="menu" style="list-style: none; margin: 0; padding: 0; width: 300px;">
+  <li role="menuitem" style="padding: 8px 0;">First group item</li>
+  <RcSeparator :decorative="false" style="border-top: 1px solid var(--border);" />
+  <li role="menuitem" style="padding: 8px 0;">Second group item</li>
+</ul>`;
+
+export const Semantic: Story = {
+  render: () => ({
+    components: { RcSeparator },
+    template:   semanticTemplate,
+  }),
+  parameters: {
+    docs: {
+      description: { story: 'A meaningful separator inside a menu. Renders `role="separator"` and `aria-orientation="horizontal"` so that the grouping is announced.' },
+      canvas:      { sourceState: 'shown' },
+      source:      { code: semanticTemplate },
+    },
+  },
+};
+
+const verticalTemplate = `<div style="display: flex; align-items: center; gap: 20px; height: 40px;">
+  <span>Left</span>
+  <RcSeparator :decorative="false" orientation="vertical" />
+  <span>Right</span>
+</div>`;
+
+export const Vertical: Story = {
+  render: () => ({
+    components: { RcSeparator },
+    template:   verticalTemplate,
+  }),
+  parameters: {
+    docs: {
+      description: { story: 'A vertical separator. The component supplies the geometry for this case, so no additional styling is required.' },
+      canvas:      { sourceState: 'shown' },
+      source:      { code: verticalTemplate },
+    },
+  },
+};


### PR DESCRIPTION
This is a potential patch for rancher/dashboard#18468. It solves two problems:

1. Keeps components with the "Rc" prefix in Rancher Components
2. Promotes a single source of truth for separators

### Occurred changes and/or fixed issues

- Move `RcSeparator` to `pkg/rancher-components/src/components/RcSeparator/`
  - Add unit tests and storybook story for usage guidelines
- Updated `RcDropdownSeparator` so that it wraps `RcSeparator` to reduce duplication
- Updated imports for `RcSeparator`

### Technical notes summary

This moves `RcSeparator` into Rancher Components. The Rc prefix is reserved for Rancher Components, so a component named RcSeparator does not belong in shell/. Additionally, locating `RcSeparator` under shell also it there also forced Card.vue, to import from `@shell`. This is a pattern that we want to avoid moving forward.

`RcDropdownSeparator` now accepts decorative and orientation props that drive role and aria-orientation, and `RcDropdownSeparator` consumes it. Consuming `RcSeparator` as a thin wrapper promotes a single source of truth for separators.
